### PR TITLE
Planning updates: AUD budget, admin dashboard stance, AU grants, All Rights Reserved licence

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,7 +1,19 @@
-MIT License
+All Rights Reserved
 
 Copyright (c) 2025 Brian Cusack
 
-[Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/)
+Permission is hereby NOT granted to copy, modify, merge, publish, distribute, sublicense, and/or sell copies of this work, in whole or in part, without explicit prior written permission from the copyright holder.
 
-This work is licensed under a Creative Commons Attribution 4.0 International License.
+You may:
+- View and read this repository for personal reference.
+- Link to this repository.
+
+You may not, without prior written permission:
+- Reproduce, redistribute, or publicly host the content.
+- Create derivative works or adaptations.
+- Use the content for commercial purposes, including grant applications, pitches, or product materials.
+- Train models on, or extract datasets from, the content.
+
+Attribution: If written permission is granted for specific uses, attribution to "Brian Cusack" and a link to this repository are required.
+
+For permissions, please contact: [Insert contact or GitHub profile link]

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -16,4 +16,4 @@ You may not, without prior written permission:
 
 Attribution: If written permission is granted for specific uses, attribution to "Brian Cusack" and a link to this repository are required.
 
-For permissions, please contact: [Insert contact or GitHub profile link]
+For permissions, please contact: [BCusack](https://github.com/BCusack)

--- a/Project/Planning.md
+++ b/Project/Planning.md
@@ -62,14 +62,15 @@ This document consolidates the go-to-market plan and grant funding strategy for 
 8. Budget & Sustainability: costs, co-funding, path to revenue.
 
 ## Indicative Budget (12–18 months)
-- Personnel: £420k–£620k (ML/infra, full‑stack, HCI/privacy research, embedded, compliance)
-- Cloud/Compute: £80k–£160k (LLM usage, privacy-preserving infra, monitoring)
-- Hardware & Prototyping: £60k–£120k (ear-clip prototypes, sensors, testing rigs)
-- Research & Pilots: £70k–£140k (participant incentives, ethics approvals, analysis)
-- Security & Compliance: £40k–£90k (threat modelling, pen test, DPIA/ISO prep)
-- Legal & IP: £25k–£60k (contracts, licenses, trademarks, counsel)
-- Ops & Contingency: £35k–£75k
-Total indicative: £730k–£1.27m (seek grants to cover 40–70%; remainder via in-kind/credits/match)
+Note: Converted from GBP at a planning rate of 1 GBP = 2.0 AUD; update with current rates during detailed budgeting.
+- Personnel: AUD 840k–1.24m (ML/infra, full‑stack, HCI/privacy research, embedded, compliance)
+- Cloud/Compute: AUD 160k–320k (LLM usage, privacy‑preserving infra, monitoring)
+- Hardware & Prototyping: AUD 120k–240k (ear‑clip prototypes, sensors, testing rigs)
+- Research & Pilots: AUD 140k–280k (participant incentives, ethics approvals, analysis)
+- Security & Compliance: AUD 80k–180k (threat modelling, pen test, DPIA/ISO prep)
+- Legal & IP: AUD 50k–120k (contracts, licences, trademarks, counsel)
+- Ops & Contingency: AUD 70k–150k
+Total indicative: AUD 1.46m–2.54m (seek grants to cover 40–70%; remainder via in‑kind/credits/match)
 
 ## Work Packages (WPs) & KPIs
 - WP0: Technology Discovery
@@ -106,15 +107,6 @@ Total indicative: £730k–£1.27m (seek grants to cover 40–70%; remainder via
 ## Partnerships & Letters of Support (Initial Targets)
  Academic: AU HCI/privacy labs; affective computing groups.
  Industry: ear-wearable OEMs, cloud providers, privacy tooling vendors; CSIRO/Data61 collaboration opportunities.
-
- Note: Figures currently shown in GBP for comparability; will be localised to AUD in the next revision.
- Personnel: £420k–£620k (ML/infra, full‑stack, HCI/privacy research, embedded, compliance)
- Cloud/Compute: £80k–£160k (LLM usage, privacy-preserving infra, monitoring)
- Hardware & Prototyping: £60k–£120k (ear-clip prototypes, sensors, testing rigs)
- Research & Pilots: £70k–£140k (participant incentives, ethics approvals, analysis)
- Security & Compliance: £40k–£90k (threat modelling, pen test, DPIA/ISO prep)
- Legal & IP: £25k–£60k (contracts, licenses, trademarks, counsel)
- Ops & Contingency: £35k–£75k
 Advisory group (part‑time/retained):
 - Clinical/Wellbeing Advisor: risk boundaries, escalation protocols.
 - Ethics/AI Safety Advisor: review policies, red‑team oversight.

--- a/Project/Planning.md
+++ b/Project/Planning.md
@@ -8,6 +8,7 @@ This document consolidates the go-to-market plan and grant funding strategy for 
 
 ## Objectives (12–18 months)
 - Validate problem–solution fit for an always-on, privacy-first AI companion.
+- Complete a structured technology discovery and feasibility assessment (build‑vs‑buy, latency, privacy, and reliability constraints).
 - Build and test an MVP across 2–3 usage domains (wellbeing support, micro-assistance, and context-awareness).
 - Secure non-dilutive grant funding to achieve technical milestones and ethical compliance readiness.
 - Establish partnerships for hardware prototyping, privacy research, and pilot deployments.
@@ -15,8 +16,10 @@ This document consolidates the go-to-market plan and grant funding strategy for 
 ## Phased Roadmap
 - Phase 0: Foundations (Month 0–2)
   - Technical: architecture choices, safety/ethics framework, risk register.
+  - Technology discovery: survey candidate stacks (ASR/TTS, on-device inference, LLM orchestration), run feasibility spikes, and produce a decision matrix with trade-offs and costs.
   - Research: user needs discovery, refine personas, pilot protocols.
   - Ops: grant pipeline creation, governance setup, initial letters of support.
+  - Gating criteria: architecture option(s) shortlisted with rationale; feasibility spikes demonstrate target latency and privacy posture on representative hardware; build‑vs‑buy decisions recorded; privacy threat model v1.
 - Phase 1: MVP v1 (Month 3–6)
   - Deliverables: ear-clip interaction prototype (mock hardware), admin dashboard app for analysis and controls, core LLM integration, ephemeral context buffer.
   - Gating criteria: live end-to-end demo, privacy threat model v1, 20 pilot users recruited.
@@ -59,6 +62,9 @@ This document consolidates the go-to-market plan and grant funding strategy for 
 Total indicative: £730k–£1.27m (seek grants to cover 40–70%; remainder via in-kind/credits/match)
 
 ## Work Packages (WPs) & KPIs
+- WP0: Technology Discovery
+  - Outputs: discovery plan, evaluation matrix (build‑vs‑buy, cost/latency/privacy), feasibility spike reports, recommended architecture baseline.
+  - KPIs: latency target on reference device (e.g., <350ms E2E voice loop), on-device/private-by-default coverage %, projected monthly compute cost within budget envelope, decision record completeness.
 - WP1: Core Interaction & Safety
   - Outputs: low-latency voice loop, policy guardrails, fallback UX.
   - KPIs: <350ms perceived latency; false-positive/negative safety rates; session completion rate.

--- a/Project/Planning.md
+++ b/Project/Planning.md
@@ -18,7 +18,7 @@ This document consolidates the go-to-market plan and grant funding strategy for 
 - Build and test an MVP across 2–3 usage domains (wellbeing support, micro-assistance, and context-awareness).
 - Secure non-dilutive grant funding to achieve technical milestones and ethical compliance readiness.
 - Establish partnerships for hardware prototyping, privacy research, and pilot deployments.
-- Assemble a small interdisciplinary core team (ML/infra, full‑stack, HCI/privacy research, embedded/firmware) and an external advisory group (clinical/wellbeing, ethics, hardware).
+- Assemble a small interdisciplinary core team (ML/infra, full‑stack, human–computer interaction (HCI)/privacy research, embedded/firmware) and an external advisory group (clinical/wellbeing, ethics, hardware).
 
 ## Phased Roadmap
 - Phase 0: Foundations (Month 0–3)
@@ -46,7 +46,7 @@ This document consolidates the go-to-market plan and grant funding strategy for 
 - Approach:
   - Maintain a rolling grant calendar with deadlines, TRL fit, match funding needs, and eligibility.
   - Prepare a reusable application core: problem, innovation, impact, team, work packages, ethics, risk.
-  - Build a partner network for letters of support: universities (HCI/Privacy), clinics/wellbeing orgs, device makers.
+  - Build a partner network for letters of support: universities (HCI/privacy), clinics/wellbeing orgs, device makers.
   - Evidence: cite `Whitepaper.md` sections (memory, ethics, comms), and `Project/Market Research.md`.
 
 ### Grant Narrative Outline (Reusable)

--- a/Project/Planning.md
+++ b/Project/Planning.md
@@ -63,14 +63,14 @@ This document consolidates the go-to-market plan and grant funding strategy for 
 
 ## Indicative Budget (12–18 months)
 Note: Converted from GBP at a planning rate of 1 GBP = 2.0 AUD; update with current rates during detailed budgeting.
-- Personnel: AUD 840k–1.24m (ML/infra, full‑stack, HCI/privacy research, embedded, compliance)
-- Cloud/Compute: AUD 160k–320k (LLM usage, privacy‑preserving infra, monitoring)
-- Hardware & Prototyping: AUD 120k–240k (ear‑clip prototypes, sensors, testing rigs)
-- Research & Pilots: AUD 140k–280k (participant incentives, ethics approvals, analysis)
-- Security & Compliance: AUD 80k–180k (threat modelling, pen test, DPIA/ISO prep)
-- Legal & IP: AUD 50k–120k (contracts, licences, trademarks, counsel)
-- Ops & Contingency: AUD 70k–150k
-Total indicative: AUD 1.46m–2.54m (seek grants to cover 40–70%; remainder via in‑kind/credits/match)
+- Personnel: $840k–$1.24m (ML/infra, full‑stack, HCI/privacy research, embedded, compliance)
+- Cloud/Compute: $160k–$320k (LLM usage, privacy‑preserving infra, monitoring)
+- Hardware & Prototyping: $120k–$240k (ear‑clip prototypes, sensors, testing rigs)
+- Research & Pilots: $140k–$280k (participant incentives, ethics approvals, analysis)
+- Security & Compliance: $80k–$180k (threat modelling, pen test, DPIA/ISO prep)
+- Legal & IP: $50k–$120k (contracts, licences, trademarks, counsel)
+- Ops & Contingency: $70k–$150k
+Total indicative: $1.46m–$2.54m (seek grants to cover 40–70%; remainder via in‑kind/credits/match)
 
 ## Work Packages (WPs) & KPIs
 - WP0: Technology Discovery
@@ -125,3 +125,5 @@ Engagement model and timing:
 
 ---
 This document is a living plan; updates should be cross-referenced in `Whitepaper.md` and `Extended/` notes.
+
+Note: All monetary amounts are in AUD.

--- a/Project/Planning.md
+++ b/Project/Planning.md
@@ -6,20 +6,28 @@ Owner: Seon Core Team
 ## Overview
 This document consolidates the go-to-market plan and grant funding strategy for Seon. It complements the project vision in `Whitepaper.md` and competitive insights in `Project/Market Research.md`.
 
+## Guiding Principles
+- Ambient, ear-first interactions; no consumer smartphone application. The smartphone is not the primary interface.
+- Admin dashboard exists solely for pilot operations, analysis, and controls.
+- Privacy by design: data minimisation, on-device processing where feasible, encrypted cloud only for heavy compute.
+- Low-latency voice loop and context awareness via device mesh, not phone-centric hubs.
+
 ## Objectives (12–18 months)
 - Validate problem–solution fit for an always-on, privacy-first AI companion.
 - Complete a structured technology discovery and feasibility assessment (build‑vs‑buy, latency, privacy, and reliability constraints).
 - Build and test an MVP across 2–3 usage domains (wellbeing support, micro-assistance, and context-awareness).
 - Secure non-dilutive grant funding to achieve technical milestones and ethical compliance readiness.
 - Establish partnerships for hardware prototyping, privacy research, and pilot deployments.
+- Assemble a small interdisciplinary core team (ML/infra, full‑stack, HCI/privacy research, embedded/firmware) and an external advisory group (clinical/wellbeing, ethics, hardware).
 
 ## Phased Roadmap
-- Phase 0: Foundations (Month 0–2)
+- Phase 0: Foundations (Month 0–3)
   - Technical: architecture choices, safety/ethics framework, risk register.
   - Technology discovery: survey candidate stacks (ASR/TTS, on-device inference, LLM orchestration), run feasibility spikes, and produce a decision matrix with trade-offs and costs.
   - Research: user needs discovery, refine personas, pilot protocols.
   - Ops: grant pipeline creation, governance setup, initial letters of support.
-  - Gating criteria: architecture option(s) shortlisted with rationale; feasibility spikes demonstrate target latency and privacy posture on representative hardware; build‑vs‑buy decisions recorded; privacy threat model v1.
+  - Team: prioritise hiring/contracting for critical roles and onboard advisors.
+  - Gating criteria: architecture option(s) shortlisted with rationale; feasibility spikes demonstrate target latency and privacy posture on representative hardware; build‑vs‑buy decisions recorded; privacy threat model v1; signed letters of support; at least two key advisors engaged; hiring plan approved and critical roles filled or contracted.
 - Phase 1: MVP v1 (Month 3–6)
   - Deliverables: ear-clip interaction prototype (mock hardware), admin dashboard app for analysis and controls, core LLM integration, ephemeral context buffer.
   - Gating criteria: live end-to-end demo, privacy threat model v1, 20 pilot users recruited.
@@ -52,7 +60,7 @@ This document consolidates the go-to-market plan and grant funding strategy for 
 8. Budget & Sustainability: costs, co-funding, path to revenue.
 
 ## Indicative Budget (12–18 months)
-- Personnel: £420k–£620k (ML/infra, full-stack, product, research, compliance)
+- Personnel: £420k–£620k (ML/infra, full‑stack, HCI/privacy research, embedded, compliance)
 - Cloud/Compute: £80k–£160k (LLM usage, privacy-preserving infra, monitoring)
 - Hardware & Prototyping: £60k–£120k (ear-clip prototypes, sensors, testing rigs)
 - Research & Pilots: £70k–£140k (participant incentives, ethics approvals, analysis)
@@ -97,6 +105,23 @@ Total indicative: £730k–£1.27m (seek grants to cover 40–70%; remainder via
 - Academic: HCI/privacy labs; affective computing groups.
 - Clinical/Wellbeing: mental health charities, digital therapeutics clinics.
 - Industry: ear-wearable OEMs, cloud providers, privacy tooling vendors.
+
+## Team & Roles
+Core team (first 3–6 months):
+- ML/Inference Engineer (edge and cloud): low-latency ASR/TTS pipeline, on-device inference, LLM orchestration.
+- Full‑Stack Engineer: admin dashboard, data pipeline, telemetry with privacy by design.
+- HCI/Privacy Researcher: study design, DPIA, threat modelling, ethics compliance.
+- Embedded/Firmware Engineer (as needed): prototype ear‑wearable firmware and sensor integration.
+
+Advisory group (part‑time/retained):
+- Clinical/Wellbeing Advisor: risk boundaries, escalation protocols.
+- Ethics/AI Safety Advisor: review policies, red‑team oversight.
+- Hardware/EE Advisor: ear‑wearable feasibility and vendor evaluation.
+
+Engagement model and timing:
+- Month 0–1: contract advisors; engage 1–2 core engineers; HCI/privacy researcher part‑time.
+- Month 2–3: expand to full core team; kick off pilots preparation.
+- Use contractors/partners where faster, convert to FTE as funding permits.
 
 ## Next Actions
 - Build grant calendar and assign owners per opportunity.

--- a/Project/Planning.md
+++ b/Project/Planning.md
@@ -38,15 +38,17 @@ This document consolidates the go-to-market plan and grant funding strategy for 
   - Deliverables: security review, device-mesh reliability tests, data minimisation compliance pack.
   - Gating criteria: retention ≥40% at 30 days, NPS ≥25, privacy audit pass.
 
-## Grant Strategy
-- Targets (examples; to be tailored by region):
-  - National innovation agencies (e.g., UKRI Innovate UK Smart Grants; EU EIC Pathfinder/Transition; US NSF SBIR/STTR).
-  - Foundations focused on digital health, wellbeing, and privacy (e.g., Wellcome Trust; Mozilla; Sloan; Omidyar; OpenAI Community Fund-equivalents where applicable).
-  - Industry-aligned programmes (cloud credits, hardware incubators, responsible AI funds).
+## Grant Strategy (Australia‑focused)
+- Targets (Australia):
+  - Federal: Accelerating Commercialisation/Industry Growth Program (IGP), CRC‑P (Cooperative Research Centres Projects), ARC Linkage, MRFF/NHMRC (digital health/mental health), Export Market Development Grants (EMDG).
+  - CSIRO & National Science: CSIRO Kick‑Start, ON Prime/Accelerate, Data61 collaborations.
+  - State: NSW MVP Ventures, QLD Ignite Ideas, Vic Breakthrough Victoria, SA Research/Commercialisation grants.
+  - Philanthropy: Paul Ramsay Foundation, Minderoo, Lord Mayor’s Charitable Foundation; privacy/tech foundations where applicable.
+  - Industry: cloud credits (AWS/Azure/GCP), hardware prototyping programs, responsible AI funds.
 - Approach:
   - Maintain a rolling grant calendar with deadlines, TRL fit, match funding needs, and eligibility.
   - Prepare a reusable application core: problem, innovation, impact, team, work packages, ethics, risk.
-  - Build a partner network for letters of support: universities (HCI/privacy), clinics/wellbeing orgs, device makers.
+  - Build a partner network for letters of support: AU universities (HCI/privacy), CSIRO/Data61, clinics/wellbeing orgs, device makers.
   - Evidence: cite `Whitepaper.md` sections (memory, ethics, comms), and `Project/Market Research.md`.
 
 ### Grant Narrative Outline (Reusable)
@@ -98,21 +100,21 @@ Total indicative: £730k–£1.27m (seek grants to cover 40–70%; remainder via
 
 ## Ethics, Legal, and IP
 - Ethics: participant consent, opt-out by default for sensitive capture, transparent summaries.
-- Legal/Compliance: DPIA, ISO 27001 readiness, clinical oversight for wellbeing features.
+- Legal/Compliance: DPIA, ISO 27001 readiness, clinical oversight for wellbeing features. Australia‑specific: align with the Australian Privacy Principles (APPs) and OAIC Notifiable Data Breaches (NDB) scheme; for human research, obtain HREC approval in line with the NHMRC National Statement.
 - IP/Licensing: protect brand and hardware designs; prefer open standards; document data rights.
 
 ## Partnerships & Letters of Support (Initial Targets)
-- Academic: HCI/privacy labs; affective computing groups.
-- Clinical/Wellbeing: mental health charities, digital therapeutics clinics.
-- Industry: ear-wearable OEMs, cloud providers, privacy tooling vendors.
+ Academic: AU HCI/privacy labs; affective computing groups.
+ Industry: ear-wearable OEMs, cloud providers, privacy tooling vendors; CSIRO/Data61 collaboration opportunities.
 
-## Team & Roles
-Core team (first 3–6 months):
-- ML/Inference Engineer (edge and cloud): low-latency ASR/TTS pipeline, on-device inference, LLM orchestration.
-- Full‑Stack Engineer: admin dashboard, data pipeline, telemetry with privacy by design.
-- HCI/Privacy Researcher: study design, DPIA, threat modelling, ethics compliance.
-- Embedded/Firmware Engineer (as needed): prototype ear‑wearable firmware and sensor integration.
-
+ Note: Figures currently shown in GBP for comparability; will be localised to AUD in the next revision.
+ Personnel: £420k–£620k (ML/infra, full‑stack, HCI/privacy research, embedded, compliance)
+ Cloud/Compute: £80k–£160k (LLM usage, privacy-preserving infra, monitoring)
+ Hardware & Prototyping: £60k–£120k (ear-clip prototypes, sensors, testing rigs)
+ Research & Pilots: £70k–£140k (participant incentives, ethics approvals, analysis)
+ Security & Compliance: £40k–£90k (threat modelling, pen test, DPIA/ISO prep)
+ Legal & IP: £25k–£60k (contracts, licenses, trademarks, counsel)
+ Ops & Contingency: £35k–£75k
 Advisory group (part‑time/retained):
 - Clinical/Wellbeing Advisor: risk boundaries, escalation protocols.
 - Ethics/AI Safety Advisor: review policies, red‑team oversight.

--- a/Project/Planning.md
+++ b/Project/Planning.md
@@ -62,7 +62,6 @@ This document consolidates the go-to-market plan and grant funding strategy for 
 8. Budget & Sustainability: costs, co-funding, path to revenue.
 
 ## Indicative Budget (12–18 months)
-Note: Converted from GBP at a planning rate of 1 GBP = 2.0 AUD; update with current rates during detailed budgeting.
 - Personnel: $840k–$1.24m (ML/infra, full‑stack, HCI/privacy research, embedded, compliance)
 - Cloud/Compute: $160k–$320k (LLM usage, privacy‑preserving infra, monitoring)
 - Hardware & Prototyping: $120k–$240k (ear‑clip prototypes, sensors, testing rigs)

--- a/Project/Planning.md
+++ b/Project/Planning.md
@@ -18,7 +18,7 @@ This document consolidates the go-to-market plan and grant funding strategy for 
   - Research: user needs discovery, refine personas, pilot protocols.
   - Ops: grant pipeline creation, governance setup, initial letters of support.
 - Phase 1: MVP v1 (Month 3–6)
-  - Deliverables: ear-clip interaction prototype (mock hardware), mobile companion app, core LLM integration, ephemeral context buffer.
+  - Deliverables: ear-clip interaction prototype (mock hardware), admin dashboard app for analysis and controls, core LLM integration, ephemeral context buffer.
   - Gating criteria: live end-to-end demo, privacy threat model v1, 20 pilot users recruited.
 - Phase 2: Pilot & Iteration (Month 7–10)
   - Deliverables: memory graph v1, adaptive prompt/policy tuning, sentiment and intent inference.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The extended document are documents that expand on the ideas of the white paper.
 This refers to extended insights and expansions on the white paper discussion.[Read the extended document](Extended/communication_interfacing.md)
 
 
-## License
-This research is licensed under the Creative Commons Attribution 4.0 International License. See the [LICENSE.md](LICENSE.md) file for details.
+## Licence
+This research is provided under an All Rights Reserved licence. See the [LICENCE.md](LICENCE.md) file for details.
 
 ## Authors and Research tooling
 - Brian Cusack


### PR DESCRIPTION
This PR updates planning and licensing docs to reflect the current direction and regional focus.

Highlights
- Planning & Grants (Australia):
  - Converted Indicative Budget to AUD with $ notation and added an AUD note.
  - Admin dashboard (no consumer mobile app), ear-first, privacy-first principles.
  - Added Phase 0 Technology Discovery and WP0 gate criteria.
  - Extended Foundations timeline (0–3 months), team assembly and roles.
  - AU-localised grant strategy (IGP/CRC-P/ARC/MRFF/NHMRC, CSIRO/Data61, state programs), ethics (APPs/OAIC/HREC).
- Whitepaper & narrative adjustments (prior commits):
  - Less prescriptive “Future of AI Communication” framing; strengthened LLM interaction.
  - Memory management deepened (salience, knowledge graph) with citations; UK English.
- Licensing:
  - Switched to an All Rights Reserved licence; updated README and contributor instructions.

Housekeeping
- Removed duplicated GBP budget block under Partnerships.
- UK English consistency (e.g., licences).

Next steps (optional)
- Add a grant calendar scaffold and 2‑page concept note template.
- Fill in permissions contact in LICENCE.md.

Please review and merge when ready.