### PR TITLE
Planning: AU grant strategy + IGP links, Grant Calendar

### DIFF
--- a/Project/Planning.md
+++ b/Project/Planning.md
@@ -128,26 +128,17 @@ Engagement model and timing:
 - Prepare ethics pre-review checklist for pilots.
 
 ## Grant Calendar (rolling)
-- Industry Growth Program — Advisory Services
-  - Status: Open (apply anytime). Prerequisite for IGP grants.
-  - Action: Submit Advisory application; target advisory report within 4–6 weeks.
-  - Owner: [assign]
-- Industry Growth Program — Grants (Early-Stage: $50k–$250k; Commercialisation & Growth: $100k–$5m)
-  - Status: Open to those with IGP Advisory report; merit-based, rolling intakes.
-  - Action: Prepare grant core pack (problem, innovation, TRL, budget, ethics); align to NRF priority areas.
-  - Owner: [assign]
-- ASCA — Undersea Navigation Challenge (AI/autonomy relevant)
-  - Status: Open; closes Mon 3 Oct 2025, 12:00 pm AEST.
-  - Action: Evaluate fit; if in-scope, draft concept and team; register.
-  - Owner: [assign]
-- CSIRO Kick‑Start (Data61 collaboration)
-  - Status: Typically open year‑round.
-  - Action: Identify collaborator; draft 1‑pager and budget (matched funding note).
-  - Owner: [assign]
-- CSIRO ON Prime / ON Accelerate
-  - Status: Cohort‑based (dates TBC).
-  - Action: Monitor intake; prepare 1‑pager and team bios.
-  - Owner: [assign]
+ Industry Growth Program — Advisory Services
+   Status: Open (apply anytime). Prerequisite for IGP grants.
+   Action: Submit Advisory application; target advisory report within 4–6 weeks. Link: https://business.gov.au/grants-and-programs/industry-growth-program [Owner: assign]
+ ASCA — Undersea Navigation Challenge (AI/autonomy relevant)
+   Status: Open; closes Mon 3 Oct 2025, 12:00 pm AEST. Link: https://www.asca.gov.au/opportunities/undersea-navigation-challenge [Owner: assign]
+ CSIRO Kick‑Start (Data61 collaboration)
+   Status: Typically open year‑round. Link: https://www.csiro.au/en/contact (program page link pending update) [Owner: assign]
+ CSIRO ON Prime / ON Accelerate
+   Status: Cohort‑based (dates TBC). Link: https://www.csiro.au/en/contact (program page link pending update) [Owner: assign]
+ MRFF/NHMRC (digital health/AI‑enabled topics)
+   Status: Topic‑based; intermittent rounds. Links: MRFF https://www.health.gov.au/initiatives-and-programs/medical-research-future-fund | MRFF Grants Calendar https://www.health.gov.au/our-work/mrff/grant-opportunities-calendar | GrantConnect https://www.grants.gov.au/ [Owner: assign]
 - MRFF/NHMRC (digital health/AI‑enabled topics)
   - Status: Topic‑based; intermittent rounds.
   - Action: Set alerts on GrantConnect/business.gov.au; pre‑draft ethics and clinical partner letters.


### PR DESCRIPTION
This PR updates the planning and grants strategy for Seon with an actionable, AU‑focused pathway.

Highlights:
- Grants & Programs
  - Emphasise Industry Growth Program (IGP) advisory as the primary entry point; removed Accelerating Commercialisation (closed).
  - Added a rolling Grant Calendar with AI‑relevant opportunities:
    - IGP Advisory/Grants — link to business.gov.au
    - ASCA Undersea Navigation Challenge — official challenge page
    - MRFF/NHMRC — MRFF program, MRFF grants calendar, and GrantConnect links
    - CSIRO Kick‑Start/SME Connect and CSIRO ON — placeholder CSIRO contact link while program pages are moving (to be replaced when stable)
- Planning doc refinements
  - Admin dashboard (ear‑first) product stance reiterated.
  - Clarified Phase 0 (Technology Discovery) and extended Foundations timeline.

Notes:
- All currency is $ with a footnote that amounts are in AUD.
- Licence across repo is All Rights Reserved.

Next steps (follow‑up PRs):
- Replace CSIRO placeholders with live program URLs once available.
- Optionally convert Grant Calendar into a table with owner/deadline fields.
